### PR TITLE
fixed submodule paths because they are errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "compositing_io"]
 	path = compositing_io
-	url = git@github.com:Project-StudioQ/compositing_io.git
+	url = https://github.com/Project-StudioQ/compositing_io.git
 [submodule "view_layer_loader"]
 	path = view_layer_loader
 	url = https://github.com/Project-StudioQ/view_layer_loader.git
 [submodule "repair_link_collection"]
 	path = repair_link_collection
-	url = git@github.com:Project-StudioQ/repair_link_collection.git
+	url = https://github.com/Project-StudioQ/repair_link_collection.git


### PR DESCRIPTION
サブモジュールのURLがエラーになるため、通常のGithubのURLに修正しました。
このパスであれば問題なくサブモジュールが取得できました。